### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def import_requirements():
 
 
 setup(
-    name='ensembl-prodinf-ensprod_jira',
+    name='ensembl-prodinf-jira',
     version=os.getenv('CI_COMMIT_TAG', version),
     namespace_packages=['ensembl'],
     packages=find_namespace_packages(where='src', include=['ensembl.production.*']),


### PR DESCRIPTION
Fix 
 pip._internal.exceptions.DistributionNotFound: No matching distribution found for ensembl-prodinf-jira (unavailable)

Generating metadata for package ensembl-prodinf-jira produced metadata for project name ensembl-prodinf-ensprod-jira. Fix your #egg=ensembl-prodinf-jira fragments.
  ERROR: Could not find a version that satisfies the requirement ensembl-prodinf-jira (unavailable) (from versions: none)

setting up install name name='ensembl-prodinf-jira', will fix this issue 